### PR TITLE
Bump meteo_lt-pkg 0.7.2, homeassistant 2026.6.0, release 0.5.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.5.4
+
+Date: `2026-07-11`
+
+### Changes
+
+- Bumped `meteo_lt-pkg` dependency to `0.7.2`.
+
 ## Release 0.5.3
 
 Date: `2026-02-12`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Date: `2026-07-11`
 ### Changes
 
 - Bumped `meteo_lt-pkg` dependency to `0.7.2`.
+- Bumped `homeassistant` to `2026.6.0` (fixes security advisory GHSA-x84v-g949-293w) and CI Python to `3.14`.
 
 ## Release 0.5.3
 

--- a/custom_components/meteo_lt_by_brunas/manifest.json
+++ b/custom_components/meteo_lt_by_brunas/manifest.json
@@ -14,7 +14,7 @@
         "meteo_lt_by_brunas"
     ],
     "requirements": [
-        "meteo_lt-pkg>=0.7.1,<0.8.0"
+        "meteo_lt-pkg>=0.7.2,<0.8.0"
     ],
-    "version": "0.5.3"
+    "version": "0.5.4"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.10.1
-homeassistant==2026.2.3
+homeassistant==2026.6.0
 pip>=26.1.2,<27
 black
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ homeassistant==2026.2.3
 pip>=26.1.2,<27
 black
 flake8
-meteo_lt-pkg>=0.7.1,<0.8
+meteo_lt-pkg>=0.7.2,<0.8
 ruff


### PR DESCRIPTION
## Summary

- Bump `meteo_lt-pkg` dependency to `0.7.2`
- Bump `homeassistant` to `2026.6.0` — fixes security advisory [GHSA-x84v-g949-293w](https://github.com/advisories/GHSA-x84v-g949-293w) (Konnected LAN disclosure), the open Dependabot alert on `main`
- Bump CI Lint Python to `3.14` (required: HA 2026.6.0 needs Python `>=3.14.2`)
- Release integration version `0.5.4` with CHANGELOG entry

## Changes

- `requirements.txt` — `meteo_lt-pkg>=0.7.2,<0.8`, `homeassistant==2026.6.0`
- `custom_components/meteo_lt_by_brunas/manifest.json` — dep `>=0.7.2,<0.8.0`, integration `version` → `0.5.4`
- `.github/workflows/lint.yml` — `python-version` `3.13` → `3.14`
- `CHANGELOG.md` — new `Release 0.5.4` entry