### PR TITLE
Bump meteo_lt-pkg to 0.7.3, release 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.5.7
+
+Date: `2026-07-12`
+
+### Changes
+
+- Bumped `meteo_lt-pkg` dependency to `0.7.3`.
+
 ## Release 0.5.6
 
 Date: `2026-07-11`

--- a/custom_components/meteo_lt_by_brunas/manifest.json
+++ b/custom_components/meteo_lt_by_brunas/manifest.json
@@ -14,7 +14,7 @@
         "meteo_lt_by_brunas"
     ],
     "requirements": [
-        "meteo_lt-pkg>=0.7.2,<0.8.0"
+        "meteo_lt-pkg>=0.7.3,<0.8.0"
     ],
-    "version": "0.5.6"
+    "version": "0.5.7"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ homeassistant==2026.6.0
 pip>=26.1.2,<27
 black
 flake8
-meteo_lt-pkg>=0.7.2,<0.8
+meteo_lt-pkg>=0.7.3,<0.8
 ruff


### PR DESCRIPTION
## Summary
- Bump `meteo_lt-pkg` dependency to `0.7.3` in `requirements.txt` and the integration manifest
- Release `0.5.7`

## Test plan
- [ ] CI lint/build passes